### PR TITLE
Stripping this real quick, for use within a 2.5 project.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     ],
     "require": {
         "php": ">=5.3.3.",
+        "zendframework/zend-filter": "^2.5",
         "ezyang/htmlpurifier": ">=4.5.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
     ],
     "require": {
         "php": ">=5.3.3.",
-        "zendframework/zendframework": "2.*",
         "ezyang/htmlpurifier": ">=4.5.0"
     },
     "autoload": {


### PR DESCRIPTION
Requiring the entire framework causes the entire 2.5 to get downloaded.